### PR TITLE
Fix: Allow Nested Objects in Lists to generate unique values

### DIFF
--- a/docs/generators.md
+++ b/docs/generators.md
@@ -393,6 +393,10 @@ Generates a list of values of a specific type (using another generator type defi
 * `min_length` must be equal or greater than 0 
 * `min_length` must be equal or less than `max_length`
 
+#### Additional Notes
+
+* a new expression value (`kwargs.index`) value is added to support expressions requiring to know the index of the list item
+
 #### Example
 
 <caption>Simple List Example</caption>
@@ -427,6 +431,24 @@ max_length: 3
 ["df", "aaeff", "fcb"]
 ["fd", "affe"]
 ["edbb", "cadfe"]
+```
+
+<caption>Nested Object Example</caption>
+
+```yaml
+type: list
+sub_type:
+  type: object
+  properties:
+    index:
+      type: integer
+      expression: kwargs.index
+    text:
+      type: string
+```
+
+```text
+[{"index": 0, "text": "9tt27VDy"}, {"index": 1, "text": "aYsy5PlhnfhAV"}, {"index": 2, "text": "31ZCuqzULTHOr"}, {"index": 3, "text": "fAdrIQnL85RT9UYe"}]
 ```
 
 ### Object / Mapping

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ markers = [
     "docs",
     "unit",
     "integration",
+    "issue",
 ]
 
 [tool.uv]

--- a/syntrend/generators/__init__.py
+++ b/syntrend/generators/__init__.py
@@ -81,9 +81,9 @@ class PropertyGenerator:
     def validate(self):
         pass
 
-    def render(self):
+    def render(self, force=False, **kwargs):
         iteration = self.root_manager.current_iteration(self.root_object)
-        if self.iteration == iteration:
+        if self.iteration == iteration and not force:
             return self.iteration_value
 
         self.iteration = iteration

--- a/syntrend/generators/__init__.py
+++ b/syntrend/generators/__init__.py
@@ -94,7 +94,9 @@ class PropertyGenerator:
         generated = self.generate(**kwargs)
         try:
             self.iteration_value = self.expression(
-                new=generated, interval=self.iteration, kwargs=self.kwargs._asdict() | kwargs
+                new=generated,
+                interval=self.iteration,
+                kwargs=self.kwargs._asdict() | kwargs,
             )
         except (ValueError, TypeError) as e:
             exc.process_exception(e)

--- a/syntrend/generators/__init__.py
+++ b/syntrend/generators/__init__.py
@@ -91,10 +91,10 @@ class PropertyGenerator:
             self.iteration_value = self.start
             return self.start
 
-        generated = self.generate()
+        generated = self.generate(**kwargs)
         try:
             self.iteration_value = self.expression(
-                new=generated, interval=self.iteration, kwargs=self.kwargs
+                new=generated, interval=self.iteration, kwargs=self.kwargs._asdict() | kwargs
             )
         except (ValueError, TypeError) as e:
             exc.process_exception(e)
@@ -106,7 +106,7 @@ class PropertyGenerator:
     def undo(self):
         self.iteration -= 1
 
-    def generate(self):
+    def generate(self, **kwargs):
         raise NotImplementedError('Generator has not implemented `generate` method')
 
 

--- a/syntrend/generators/choice.py
+++ b/syntrend/generators/choice.py
@@ -24,5 +24,5 @@ class ChoiceGenerator(PropertyGenerator):
     def validate(self):
         assert len(self.items) > 0, 'Cannot generate items from an empty list'
 
-    def generate(self):
+    def generate(self, **_):
         return self.items[randint(0, len(self.items) - 1)]

--- a/syntrend/generators/complex_object.py
+++ b/syntrend/generators/complex_object.py
@@ -46,7 +46,7 @@ class UnionGeneratorBase(BaseComplexGenerator):
             )
         return _gens
 
-    def generate(self) -> any:
+    def generate(self, **_) -> any:
         return self.items[randint(0, len(self.items) - 1)].render()
 
 
@@ -73,18 +73,20 @@ class ListGeneratorBase(BaseComplexGenerator):
         assert 'sub_type' in kwargs, (
             "Must provide a 'sub_type' property for the values to be generated"
         )
-        kwargs['sub_type'] = get_generator(
+        kwargs['sub_type_generator'] = get_generator(
             self.root_object,
-            PropertyDefinition(**kwargs['sub_type']),
+            PropertyDefinition(index=0, **kwargs['sub_type']),
             self.root_manager,
         )
         return kwargs
 
-    def generate(self) -> list[any]:
-        return [
-            self.kwargs.sub_type.generate()
-            for _ in range(randint(self.kwargs.min_length, self.kwargs.max_length))
-        ]
+    def generate(self, **kwargs) -> list[any]:
+        result = []
+        kwargs['force'] = True
+        for index in range(randint(self.kwargs.min_length, self.kwargs.max_length)):
+            kwargs['index'] = index
+            result.append(self.kwargs.sub_type_generator.render(**kwargs))
+        return result
 
 
 @register
@@ -105,10 +107,8 @@ class ObjectGeneratorBase(BaseComplexGenerator):
             for key in properties
         }
 
-    def generate(self):
-        for key in self.properties:
-            self.properties[key].render()
-        return {key: self.properties[key].render() for key in self.properties}
+    def generate(self, **kwargs):
+        return {key: self.properties[key].render(force=True, **kwargs) for key in self.properties}
 
     def undo(self):
         super(BaseComplexGenerator, self).undo()

--- a/syntrend/generators/complex_object.py
+++ b/syntrend/generators/complex_object.py
@@ -75,7 +75,7 @@ class ListGeneratorBase(BaseComplexGenerator):
         )
         kwargs['sub_type_generator'] = get_generator(
             self.root_object,
-            PropertyDefinition(index=0, **kwargs['sub_type']),
+            PropertyDefinition(**kwargs['sub_type']),
             self.root_manager,
         )
         return kwargs

--- a/syntrend/generators/complex_object.py
+++ b/syntrend/generators/complex_object.py
@@ -108,7 +108,10 @@ class ObjectGeneratorBase(BaseComplexGenerator):
         }
 
     def generate(self, **kwargs):
-        return {key: self.properties[key].render(force=True, **kwargs) for key in self.properties}
+        return {
+            key: self.properties[key].render(force=True, **kwargs)
+            for key in self.properties
+        }
 
     def undo(self):
         super(BaseComplexGenerator, self).undo()

--- a/syntrend/generators/datetime.py
+++ b/syntrend/generators/datetime.py
@@ -52,7 +52,7 @@ class DateTimeGenerator(PropertyGenerator):
         datetime_aware(kwargs)
         return kwargs
 
-    def generate(self):
+    def generate(self, **_):
         return (self.kwargs.generate(self) + self.kwargs.time_offset).strftime(
             self.kwargs.format
         )
@@ -71,5 +71,5 @@ class TimestampGenerator(PropertyGenerator):
         kwargs['time_offset'] = int(kwargs['time_offset'])
         return kwargs
 
-    def generate(self):
+    def generate(self, **_):
         return int(self.kwargs.generate(self).timestamp()) + self.kwargs.time_offset

--- a/syntrend/generators/float.py
+++ b/syntrend/generators/float.py
@@ -23,7 +23,7 @@ class FloatGenerator(PropertyGenerator):
         if self.kwargs.min_offset > self.kwargs.max_offset:
             raise ValueError('Min Offset must be less than or equal to Max Offset')
 
-    def generate(self):
+    def generate(self, **_):
         return round(
             self.modules.random.random() * self.kwargs.range + self.kwargs.min_offset,
             self.kwargs.num_decimals,

--- a/syntrend/generators/integer.py
+++ b/syntrend/generators/integer.py
@@ -20,7 +20,7 @@ class IntegerGenerator(PropertyGenerator):
         if self.kwargs.min_offset > self.kwargs.max_offset:
             raise ValueError('Min Offset must be less than or equal to Max Offset')
 
-    def generate(self):
+    def generate(self, **_):
         return self.modules.random.randint(
             self.kwargs.min_offset, self.kwargs.max_offset
         )

--- a/syntrend/generators/names.py
+++ b/syntrend/generators/names.py
@@ -10,7 +10,7 @@ class NameGenerator(PropertyGenerator):
     type = str
     name = 'name'
 
-    def generate(self):
+    def generate(self, **_):
         return fake.name()
 
 
@@ -19,7 +19,7 @@ class FirstNameGenerator(PropertyGenerator):
     type = str
     name = 'first_name'
 
-    def generate(self):
+    def generate(self, **_):
         return fake.first_name()
 
 
@@ -28,5 +28,5 @@ class LastNameGenerator(PropertyGenerator):
     type = str
     name = 'last_name'
 
-    def generate(self):
+    def generate(self, **_):
         return fake.last_name()

--- a/syntrend/generators/static.py
+++ b/syntrend/generators/static.py
@@ -9,5 +9,5 @@ class StaticGenerator(PropertyGenerator):
         if not hasattr(self.kwargs, 'value'):
             raise AttributeError("Static Generator requires a 'value' property")
 
-    def generate(self):
+    def generate(self, **_):
         return self.kwargs.value

--- a/syntrend/generators/string.py
+++ b/syntrend/generators/string.py
@@ -60,7 +60,7 @@ class StringGenerator(PropertyGenerator):
         if self.kwargs.min_length > self.kwargs.max_length:
             raise ValueError('Min Length must be less than or equal to Max length')
 
-    def generate(self):
+    def generate(self, **_):
         return ''.join(
             [
                 self.kwargs.chars[randint(0, len(self.kwargs.chars) - 1)]
@@ -94,7 +94,7 @@ class HexGenerator(StringGenerator):
         )
         assert self.kwargs.char_length >= 0, 'Cannot generate string from an empty list'
 
-    def generate(self):
+    def generate(self, **_):
         return ''.join(
             [
                 self.kwargs.chars[randint(0, self.kwargs.char_length)]

--- a/syntrend/generators/uuid.py
+++ b/syntrend/generators/uuid.py
@@ -18,7 +18,7 @@ class UUIDGenerator(PropertyGenerator):
         kwargs['separator'] = str(kwargs['separator'])
         return kwargs
 
-    def generate(self):
+    def generate(self, **_):
         uuid_val = self.modules.uuid.uuid4()
         if self.kwargs.compact:
             uuid_val = uuid_val.hex

--- a/tests/generators/conftest.py
+++ b/tests/generators/conftest.py
@@ -1,0 +1,8 @@
+from syntrend import generators
+
+from pytest import fixture
+
+
+@fixture(scope='function', autouse=True)
+def load_generators():
+    generators.load_generators()

--- a/tests/generators/test_generators.py
+++ b/tests/generators/test_generators.py
@@ -29,7 +29,7 @@ def test_load_default_generator():
 class RandomTestGenerator(generators.PropertyGenerator):
     name = 'test'
 
-    def generate(self):
+    def generate(self, **_):
         return 1, 'test', self.config.kwargs
 
 

--- a/tests/generators/test_generators.py
+++ b/tests/generators/test_generators.py
@@ -4,14 +4,9 @@ import syntrend.generators.string as string_gen
 
 from functools import partial
 
-from pytest import mark, fixture
+from pytest import mark
 
 Prop_Def = partial(model.PropertyDefinition, name='test')
-
-
-@fixture(scope='function', autouse=True)
-def load_generators():
-    generators.load_generators()
 
 
 @mark.unit

--- a/tests/generators/test_list.py
+++ b/tests/generators/test_list.py
@@ -1,5 +1,5 @@
-from syntrend.config import model, load_config
-from syntrend.generators import get_generator, PropertyGenerator
+from syntrend.config import load_config
+from syntrend.generators import PropertyGenerator
 from syntrend.utils.manager import ROOT_MANAGER
 
 from pytest import mark
@@ -15,27 +15,47 @@ def prepare_generator(object_def: dict) -> PropertyGenerator:
 @mark.issue(id=18)
 @mark.unit
 def test_simple_string_list():
-    generator = prepare_generator({'type': 'list', 'min_length': 6, 'max_length': 6, 'sub_type': {'type': 'string'}})
+    generator = prepare_generator(
+        {
+            'type': 'list',
+            'min_length': 6,
+            'max_length': 6,
+            'sub_type': {'type': 'string'},
+        }
+    )
     result = generator.generate()
     assert type(result) is list, 'List Generators should generate a list'
     assert len(result) == 6, 'The list should have 6 elements'
-    assert all([type(value) is str for value in result]), 'The list should contain all strings'
+    assert all([type(value) is str for value in result]), (
+        'The list should contain all strings'
+    )
 
 
 @mark.issue(id=18)
 @mark.unit
 def test_simple_number_list():
-    generator = prepare_generator({'type': 'list', 'min_length': 6, 'max_length': 6, 'sub_type': {'type': 'integer'}})
+    generator = prepare_generator(
+        {
+            'type': 'list',
+            'min_length': 6,
+            'max_length': 6,
+            'sub_type': {'type': 'integer'},
+        }
+    )
     result = generator.generate()
     assert type(result) is list, 'List Generators should generate a list'
     assert len(result) == 6, 'The list should have 6 elements'
-    assert all([type(value) is int for value in result]), 'The list should contain all strings'
+    assert all([type(value) is int for value in result]), (
+        'The list should contain all strings'
+    )
 
 
 @mark.issue(id=18)
 @mark.unit
 def test_simple_incremental_list():
-    generator = prepare_generator({'type': 'list', 'sub_type': {'type': 'integer', 'expression': 'kwargs.index'}})
+    generator = prepare_generator(
+        {'type': 'list', 'sub_type': {'type': 'integer', 'expression': 'kwargs.index'}}
+    )
     result = generator.render()
     current = -1
     for value in result:
@@ -46,11 +66,18 @@ def test_simple_incremental_list():
 @mark.issue(id=18)
 @mark.unit
 def test_complex_string_list():
-    generator = prepare_generator({'type': 'list', 'sub_type': {'type': 'object', 'properties': {'text': {'type': 'string'}}}})
+    generator = prepare_generator(
+        {
+            'type': 'list',
+            'sub_type': {'type': 'object', 'properties': {'text': {'type': 'string'}}},
+        }
+    )
     result = generator.generate()
     previous = ''
     for value in result:
         assert type(value) is dict, 'Values in list should be a dictionary/object'
         assert 'text' in value, 'Value object should contain a "text" property'
         assert type(value['text']) is str, 'Text Value should contain a string'
-        assert value['text'] != previous, 'Previous "text" value should be unique from other values'
+        assert value['text'] != previous, (
+            'Previous "text" value should be unique from other values'
+        )

--- a/tests/generators/test_list.py
+++ b/tests/generators/test_list.py
@@ -81,3 +81,17 @@ def test_complex_string_list():
         assert value['text'] != previous, (
             'Previous "text" value should be unique from other values'
         )
+
+
+@mark.issue(id=18)
+@mark.unit
+def test_index_support_from_object():
+    generator = prepare_generator(
+        {
+            'type': 'list',
+            'sub_type': {'type': 'object', 'properties': {'index': {'type': 'integer', 'expression': 'kwargs.index'}}},
+        }
+    )
+    result = generator.generate()
+    for index, value in enumerate(result):
+        assert value['index'] == index, "`index` value in object should be it's index position in the list"

--- a/tests/generators/test_list.py
+++ b/tests/generators/test_list.py
@@ -89,9 +89,16 @@ def test_index_support_from_object():
     generator = prepare_generator(
         {
             'type': 'list',
-            'sub_type': {'type': 'object', 'properties': {'index': {'type': 'integer', 'expression': 'kwargs.index'}}},
+            'sub_type': {
+                'type': 'object',
+                'properties': {
+                    'index': {'type': 'integer', 'expression': 'kwargs.index'}
+                },
+            },
         }
     )
     result = generator.generate()
     for index, value in enumerate(result):
-        assert value['index'] == index, "`index` value in object should be it's index position in the list"
+        assert value['index'] == index, (
+            "`index` value in object should be it's index position in the list"
+        )

--- a/tests/generators/test_list.py
+++ b/tests/generators/test_list.py
@@ -1,0 +1,56 @@
+from syntrend.config import model, load_config
+from syntrend.generators import get_generator, PropertyGenerator
+from syntrend.utils.manager import ROOT_MANAGER
+
+from pytest import mark
+
+
+def prepare_generator(object_def: dict) -> PropertyGenerator:
+    load_config({'simple_list': object_def})
+    ROOT_MANAGER.load()
+    generator = ROOT_MANAGER.generators['simple_list']
+    return generator
+
+
+@mark.issue(id=18)
+@mark.unit
+def test_simple_string_list():
+    generator = prepare_generator({'type': 'list', 'min_length': 6, 'max_length': 6, 'sub_type': {'type': 'string'}})
+    result = generator.generate()
+    assert type(result) is list, 'List Generators should generate a list'
+    assert len(result) == 6, 'The list should have 6 elements'
+    assert all([type(value) is str for value in result]), 'The list should contain all strings'
+
+
+@mark.issue(id=18)
+@mark.unit
+def test_simple_number_list():
+    generator = prepare_generator({'type': 'list', 'min_length': 6, 'max_length': 6, 'sub_type': {'type': 'integer'}})
+    result = generator.generate()
+    assert type(result) is list, 'List Generators should generate a list'
+    assert len(result) == 6, 'The list should have 6 elements'
+    assert all([type(value) is int for value in result]), 'The list should contain all strings'
+
+
+@mark.issue(id=18)
+@mark.unit
+def test_simple_incremental_list():
+    generator = prepare_generator({'type': 'list', 'sub_type': {'type': 'integer', 'expression': 'kwargs.index'}})
+    result = generator.render()
+    current = -1
+    for value in result:
+        assert value == current + 1, 'Values in list should increment by one'
+        current = value
+
+
+@mark.issue(id=18)
+@mark.unit
+def test_complex_string_list():
+    generator = prepare_generator({'type': 'list', 'sub_type': {'type': 'object', 'properties': {'text': {'type': 'string'}}}})
+    result = generator.generate()
+    previous = ''
+    for value in result:
+        assert type(value) is dict, 'Values in list should be a dictionary/object'
+        assert 'text' in value, 'Value object should contain a "text" property'
+        assert type(value['text']) is str, 'Text Value should contain a string'
+        assert value['text'] != previous, 'Previous "text" value should be unique from other values'


### PR DESCRIPTION
## Description

A bug reported in #18 found that List generators would produce duplicate items when using complex types, like objects.

## Work Completed

- Include a `force` argument on the internal `render` method to skip value caching within an iteration.
- Pass a set of keyword arguments to child objects to supply additional context of parent activities (like the index value of the object in a list).