### PR TITLE
Fix: Reset XML Doc when writing multiple events

### DIFF
--- a/syntrend/config/model.py
+++ b/syntrend/config/model.py
@@ -249,6 +249,17 @@ class OutputConfig(Validated):
         assert p.is_dir(), 'Path must be a directory'
         return p
 
+    def validate(self):
+        if self.collection and self.time_field:
+            raise ValueError(
+                'Cannot create a collection when time simulation is being used',
+                {
+                    'Collection': self.collection,
+                    'Time Field': self.time_field,
+                    'Format': self.format,
+                },
+            )
+
 
 # class ValueRange(BaseModel):
 #     min: T_VALUE

--- a/syntrend/formatters/__init__.py
+++ b/syntrend/formatters/__init__.py
@@ -85,6 +85,7 @@ def load_formatter(object_name: str) -> Formatter:
     output_config = CONFIG.objects[object_name].output
     output_handler = writers.setup_event_stream(object_name)
     formatter = FORMATTERS[output_config.format](object_name)
+
     if output_config.collection:
         temp_collector = TempHandler(object_name)
         temp_collector.load()
@@ -96,12 +97,8 @@ def load_formatter(object_name: str) -> Formatter:
         event = Event(event)
         if output_config.collection:
             temp_collector.write(event)
-            if isinstance(output_handler, writers.ConsoleHandler):
-                return
-            clear_target = True
-            event = temp_collector.get_collection()
-        else:
-            event = Collection(event)
+            return
+        event = Collection(event)
         formatted_output = formatter(event)
         output_handler.write(linesep.join(formatted_output) + linesep, clear_target)
 

--- a/syntrend/formatters/xml.py
+++ b/syntrend/formatters/xml.py
@@ -73,6 +73,7 @@ def xml_formatter(object_name: str):
         return element
 
     def __formatter(events: Collection) -> list[str]:
+        doc.childNodes.clear()
         root = doc
         if is_collection:
             root = doc.createElement(object_root.output.kwargs.get('xml_tag', 'data'))

--- a/tests/formatters/test_xml.py
+++ b/tests/formatters/test_xml.py
@@ -337,7 +337,10 @@ def test_multiple_documents(xml_formatter):
     formatter = xml_formatter(
         {
             'type': 'object',
-            'properties': {'attr': {'type': 'string', 'xml_attr': True}, 'value': {'type': 'string'}},
+            'properties': {
+                'attr': {'type': 'string', 'xml_attr': True},
+                'value': {'type': 'string'},
+            },
         }
     )
     output1 = formatter(

--- a/tests/formatters/test_xml.py
+++ b/tests/formatters/test_xml.py
@@ -213,7 +213,6 @@ def test_nested_list_of_objects(xml_formatter):
             },
         }
     )
-    formatter = xml.xml_formatter('test')
     output = formatter(
         Collection(
             Event(
@@ -330,3 +329,26 @@ def test_invalid_attribute_value_type(xml_formatter):
         assert result.type is ValueError, (
             'Formatting of an attribute dict value should raise ValueError'
         )
+
+
+@mark.issue(id=25)
+@mark.unit
+def test_multiple_documents(xml_formatter):
+    formatter = xml_formatter(
+        {
+            'type': 'object',
+            'properties': {'attr': {'type': 'string', 'xml_attr': True}, 'value': {'type': 'string'}},
+        }
+    )
+    output1 = formatter(
+        Collection(Event({'attr': 'attribute1', 'value': 'first_string'}))
+    )
+    assert output1[1] == '<test attr="attribute1">first_string</test>', (
+        'Generated XML should have `attr` as the XML Attribute and Value nested within'
+    )
+    output2 = formatter(
+        Collection(Event({'attr': 'attribute2', 'value': 'second_string'}))
+    )
+    assert output2[1] == '<test attr="attribute2">second_string</test>', (
+        'Generated XML should have `attr` as the XML Attribute and Value nested within'
+    )


### PR DESCRIPTION
XML Formatter uses an XML Parser using a Document Element defined on initiation. If multiple events are being processed, this document was not reset causing multiple root elements to appear, resulting in the error.

Added a line that clears all child elements in the document to reset for each new event.

Also fixed:
- Output Writers only handled writing to collections if writing to Console. Reset this so all writers can handle collections equally.