### PR TITLE
fix: Load files before checking for indexes or refs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syntrend"
-version = "0.3.0"
+version = "0.3.1"
 description = ""
 authors = [
     { name = "Will Siddall", email = "will.siddall@gmail.com" }

--- a/syntrend/config/model/document_tags.py
+++ b/syntrend/config/model/document_tags.py
@@ -38,9 +38,7 @@ class DocumentLink:
         return self.path.parent
 
     def get_reference(self):
-        if self not in DOCUMENTS:
-            DOCUMENTS.retrieve(self.path)
-        return DOCUMENTS.get_document(self)
+        return DOCUMENTS.get_reference({'path': self.path, 'index': self.index})
 
 
 class DocumentCollection:
@@ -49,13 +47,15 @@ class DocumentCollection:
         self.__sources: dict[int, Any] = {}
         self.__retriever = lambda x: None
         self.current_file: Path | None = None
+        self.__loaded_files: set[Path] = set()
 
     def clear(self):
-        self.__tags = {}
-        self.__sources = {}
-        self.__retriever = lambda x: None
+        self.__tags.clear()
+        self.__sources.clear()
+        self.__loaded_files.clear()
 
     def add_document(self, link: DocumentLink, content):
+        self.__loaded_files.add(link.path)
         self.__sources[hash(link)] = content
 
     def add_tag(self, tag_type: str, tag_value: str, link: DocumentLink):
@@ -80,6 +80,9 @@ class DocumentCollection:
         return self.__sources[hash(link)]
 
     def get_reference(self, reference: dict):
+        if 'path' in reference:
+            if reference['path'] not in self.__loaded_files:
+                self.retrieve(reference['path'])
         if reference.get('ref', ...) is not ...:
             return self.get_tag('ref', reference['ref'])
         if 'path' in reference:

--- a/syntrend/config/model/property_definition.py
+++ b/syntrend/config/model/property_definition.py
@@ -1,4 +1,4 @@
-from syntrend.config.model.base_config import Validated, dataclass, dc, parse_bases
+from syntrend.config.model.base_config import Validated, dataclass, dc, parse_bases, NullValue
 from syntrend.config.model.property_distribution import PropertyDistribution
 from syntrend.config.model.enum import DistributionTypes
 
@@ -34,8 +34,15 @@ class PropertyDefinition(Validated):
     items: list[any] = dc.field(default_factory=list)
     properties: dict[str, 'PropertyDefinition'] = dc.field(default_factory=dict)
 
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
+    def parse_type(self, type_name: str):
+        if type(type_name) is NullValue:
+            raise ValueError(
+                'No type provided',
+                {
+                    'Object': self.name,
+                },
+            ) from None
+        return type_name
 
     def parse_distribution(self, dist_type):
         if isinstance(dist_type, str):

--- a/syntrend/config/model/property_definition.py
+++ b/syntrend/config/model/property_definition.py
@@ -1,4 +1,10 @@
-from syntrend.config.model.base_config import Validated, dataclass, dc, parse_bases, NullValue
+from syntrend.config.model.base_config import (
+    Validated,
+    dataclass,
+    dc,
+    parse_bases,
+    NullValue,
+)
 from syntrend.config.model.property_distribution import PropertyDistribution
 from syntrend.config.model.enum import DistributionTypes
 

--- a/syntrend/config/parse/loader.py
+++ b/syntrend/config/parse/loader.py
@@ -9,6 +9,11 @@ from ruamel.yaml import error
 ROOT_TAG = ('pos', '.')
 
 
+def get_file_content(file_path: Path) -> str:
+    with file_path.open('r') as file_obj:
+        return file_obj.read()
+
+
 def retrieve_source(config_file: list[dict] | dict | str | Path) -> None:
     if isinstance(config_file, list | dict):
         model.DOCUMENTS.add_document(
@@ -19,8 +24,7 @@ def retrieve_source(config_file: list[dict] | dict | str | Path) -> None:
 
     content = config_file
     if (path_ref := Path(config_file).absolute()).exists():
-        with path_ref.open('r') as file_obj:
-            content = file_obj.read()
+        content = get_file_content(path_ref)
         config_file = path_ref
         if path_ref.is_relative_to(Path.cwd()):
             config_file = path_ref.relative_to(Path.cwd())

--- a/tests/config/model/test_base_config.py
+++ b/tests/config/model/test_base_config.py
@@ -151,3 +151,20 @@ def test_parse_bases_invalid_path_reference():
     assert isinstance(exc.value.args[1], dict), (
         'Exception should return additional information about the error'
     )
+
+
+@mark.issue(id=30)
+@mark.unit
+def test_document_get_ref_from_foreign_file(monkeypatch):
+    mod.DOCUMENTS.current_file = Path('project.yaml')
+    link = mod.DocumentLink('project.yaml', 1)
+    mod.DOCUMENTS.add_document(link, {'a': 1, 'b': 2})
+
+    def _retrieve(_path):
+        new_link = mod.DocumentLink('other.yaml', 0)
+        mod.DOCUMENTS.add_document(new_link, {'type': 'string'})
+        mod.DOCUMENTS.add_tag('ref', 'obj', new_link)
+
+    mod.DOCUMENTS.set_retriever(_retrieve)
+    result = mod.DOCUMENTS.get_reference({'ref': 'obj', 'path': 'other.yaml'})
+    assert result == {'type': 'string'}, 'Return should be the loaded document'

--- a/tests/config/model/test_property_definition.py
+++ b/tests/config/model/test_property_definition.py
@@ -1,0 +1,15 @@
+import syntrend.config.model.property_definition as mod
+from pytest import mark, raises
+
+
+@mark.issue(id=30)
+@mark.unit
+def test_init_no_type_raises_error():
+    with raises(ValueError) as exc:
+        _ = mod.PropertyDefinition(
+            name='no_type',
+            type=mod.NullValue(),
+        )
+    assert exc.type is ValueError, 'Should raise ValueError'
+    assert exc.value.args[0] == 'No type provided', 'Should say `type` was not provided'
+    assert exc.value.args[1]['Object'] == 'no_type', 'Should share the name of the object'

--- a/tests/config/model/test_property_definition.py
+++ b/tests/config/model/test_property_definition.py
@@ -12,4 +12,6 @@ def test_init_no_type_raises_error():
         )
     assert exc.type is ValueError, 'Should raise ValueError'
     assert exc.value.args[0] == 'No type provided', 'Should say `type` was not provided'
-    assert exc.value.args[1]['Object'] == 'no_type', 'Should share the name of the object'
+    assert exc.value.args[1]['Object'] == 'no_type', (
+        'Should share the name of the object'
+    )


### PR DESCRIPTION
Check if the referring file's documents exists in memory before retrieving an index or ref. Loads them if they are missing.